### PR TITLE
Adding improvements to pull replica efficiency

### DIFF
--- a/solr/core/src/java/org/apache/solr/cloud/RecoveryStrategy.java
+++ b/solr/core/src/java/org/apache/solr/cloud/RecoveryStrategy.java
@@ -222,8 +222,10 @@ public class RecoveryStrategy implements Runnable, Closeable {
 
     log.info("Attempting to replicate from [{}].", leaderUrl);
 
-    // send commit
-    commitOnLeader(leaderUrl);
+    // send commit if replica could be a leader
+    if (replicaType == null || Replica.Type.isLeaderType(replicaType)) {
+      commitOnLeader(leaderUrl);
+    }
 
     // use rep handler directly, so we can do this sync rather than async
     SolrRequestHandler handler = core.getRequestHandler(ReplicationHandler.PATH);

--- a/solr/core/src/java/org/apache/solr/handler/IndexFetcher.java
+++ b/solr/core/src/java/org/apache/solr/handler/IndexFetcher.java
@@ -545,7 +545,7 @@ public class IndexFetcher {
       }
 
       if (latestVersion == 0L) {
-        if (commit.getGeneration() != 0) {
+        if (IndexDeletionPolicyWrapper.getCommitTimestamp(commit) != 0L) {
           // since we won't get the files for an empty index,
           // we just clear ours and commit
           log.info("New index in Leader. Deleting mine...");

--- a/solr/solrj/src/java/org/apache/solr/common/cloud/Replica.java
+++ b/solr/solrj/src/java/org/apache/solr/common/cloud/Replica.java
@@ -123,6 +123,15 @@ public class Replica extends ZkNodeProps implements MapWriter {
     public static Type get(String name) {
       return name == null ? Type.NRT : Type.valueOf(name.toUpperCase(Locale.ROOT));
     }
+
+    /**
+     * Only certain replica types can become leaders
+     * @param type the type of a replica
+     * @return true if that type is able to be leader, false otherwise
+     */
+    public static boolean isLeaderType(Type type) {
+      return type == NRT || type == TLOG;
+    }
   }
 
   // immutable


### PR DESCRIPTION
This avoid commits calls to leader for Pull replicas and also avoid recreating the core repeatedly when the leader has no data